### PR TITLE
Fix Zenoh Timer creation causing Tokio Reactor bug 

### DIFF
--- a/v1/src/lib.rs
+++ b/v1/src/lib.rs
@@ -390,7 +390,7 @@ impl InfluxDbStorage {
         }
     }
 
-    async fn schedule_measurement_drop(&self, measurement: &str) -> ZResult<()> {
+    async fn schedule_measurement_drop(&self, measurement: &str) {
         let m_string = measurement.to_string();
         let cloned_client = self.client.clone();
         spawn_task!(async {
@@ -405,9 +405,6 @@ impl InfluxDbStorage {
                 }
             }
         });
-
-        debug!("end schedule_measurement_drop {:?}", Instant::now());
-        Ok(())
     }
 
     fn keyexpr_from_serie(&self, serie_name: &str) -> ZResult<Option<OwnedKeyExpr>> {
@@ -534,7 +531,7 @@ impl Storage for InfluxDbStorage {
             )
         }
         // schedule the drop of measurement later in the future, if it's empty
-        self.schedule_measurement_drop(measurement.as_str()).await?;
+        self.schedule_measurement_drop(measurement.as_str()).await;
         Ok(StorageInsertionResult::Deleted)
     }
 

--- a/v1/src/lib.rs
+++ b/v1/src/lib.rs
@@ -301,9 +301,7 @@ impl Volume for InfluxDbVolume {
         };
 
         // Check if the database exists (using storages credentials)
-        let client_clone = client.clone();
-        let db_name = db.clone();
-        if !is_db_existing(&client_clone, &db_name).await? {
+        if !is_db_existing(&client, &db).await? {
             if createdb {
                 // create db using backend's credentials
                 create_db(&self.admin_client, &db, storage_username).await?;

--- a/v2/src/lib.rs
+++ b/v2/src/lib.rs
@@ -15,6 +15,7 @@
 use std::{
     convert::{TryFrom, TryInto},
     str::FromStr,
+    sync::Arc,
     time::{Duration, UNIX_EPOCH},
 };
 
@@ -103,9 +104,6 @@ pub const PROP_STORAGE_ON_CLOSURE: &str = "on_closure";
 
 // Special key for None (when the prefix being stripped exactly matches the key)
 pub const NONE_KEY: &str = "@@none_key@@";
-
-// delay after deletion to drop a measurement
-// const DROP_MEASUREMENT_TIMEOUT_MS: u64 = 5000;
 
 lazy_static::lazy_static!(
     static ref INFLUX_REGEX_ALL: String = key_exprs_to_influx_regex(&["**".try_into().unwrap()]);
@@ -376,7 +374,7 @@ impl Volume for InfluxDbVolume {
             db_name,
             config,
             admin_client,
-            client,
+            client: Arc::new(client),
             on_closure,
         }))
     }
@@ -464,7 +462,7 @@ struct InfluxDbStorage {
     db_name: String,
     config: StorageConfig,
     admin_client: Client,
-    client: Client,
+    client: Arc<Client>,
     on_closure: OnClosure,
 }
 


### PR DESCRIPTION
The Zenoh `Timer` util, used here for delaying the deletion of a measurement in InfluxDB was causing a failed test whereby the timer could not find a Tokio Runtime to execute on. 

https://github.com/ZettaScaleLabs/zenoh-tests/actions/runs/10504593226

This PR removes the Timer Util, makes use of the tokio `timeout` function to achieve the same delayed deletion, 
while using the Tokio runtime of the plugin in the case of a Dynamic plugin. 